### PR TITLE
Update ValueIsInList.fmfn

### DIFF
--- a/CustomFunctions/Value/ValueIsInList.fmfn
+++ b/CustomFunctions/Value/ValueIsInList.fmfn
@@ -14,6 +14,8 @@
  * with FilterValues method.
  * @history 2015-03-18 - Jeremy Bante <http://scr.im/fugue> - Renaming function
  * to match convention.
+ * @history 2017-03-16 - Erik Shagdar - Convert to using Position instead of
+ * FilterValues to pick up NULL strings.
  ******************************************************************************/
 
-not IsEmpty ( FilterValues ( searchValue ; referenceList ) )
+Position ( "¶" & referenceList & "¶"; "¶" & searchValue & "¶"; 1; 1 ) > 0


### PR DESCRIPTION
ValueIsInList ( "Bob¶Sue¶¶Fred" ; NULL ) currently returns False when searching for an empty string. Converting FilterValues to Position would find the empty string and return True instead.